### PR TITLE
feat(wandb): add logging to W&B

### DIFF
--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -6,3 +6,4 @@ psutil
 sacrebleu
 rouge-score
 tensorflow_datasets
+wandb

--- a/examples/run_glue.py
+++ b/examples/run_glue.py
@@ -520,7 +520,8 @@ def main():
         if not _WANDB_AVAILABLE:
             logger.error("To use Weights & Biases logging, import wandb.")
         else:
-            wandb.init(config={**vars(args), 'config':config.to_dict(), 'tokenizer_config':tokenizer.init_kwargs})
+            wandb.init(config={**vars(args), 'script': os.path.basename(__file__), 'config':config.to_dict(),
+                               'tokenizer_config':tokenizer.init_kwargs})
 
     # Training
     if args.do_train:

--- a/examples/run_glue.py
+++ b/examples/run_glue.py
@@ -522,6 +522,8 @@ def main():
         else:
             wandb.init(config={**vars(args), 'script': os.path.basename(__file__), 'config':config.to_dict(),
                                'tokenizer_config':tokenizer.init_kwargs})
+        # keep track of model topology and gradients
+        wandb.watch(model)
 
     # Training
     if args.do_train:

--- a/examples/run_glue.py
+++ b/examples/run_glue.py
@@ -519,7 +519,7 @@ def main():
         if not _WANDB_AVAILABLE:
             logger.error("You want to use `wandb` which is not installed yet")
         else:
-            wandb.init(config=args)
+            wandb.init(config={**vars(args), 'config':config.to_dict(), 'tokenizer_config':tokenizer.init_kwargs})
 
     # Training
     if args.do_train:

--- a/examples/run_glue.py
+++ b/examples/run_glue.py
@@ -518,7 +518,7 @@ def main():
     # Start a wandb run
     if args.log_on_wandb:
         if not _WANDB_AVAILABLE:
-            logger.error("You want to use `wandb` which is not installed yet")
+            logger.error("To use Weights & Biases logging, import wandb.")
         else:
             wandb.init(config={**vars(args), 'config':config.to_dict(), 'tokenizer_config':tokenizer.init_kwargs})
 

--- a/examples/run_glue.py
+++ b/examples/run_glue.py
@@ -546,6 +546,10 @@ def main():
         # Good practice: save your training arguments together with the trained model
         torch.save(args, os.path.join(args.output_dir, "training_args.bin"))
 
+        # Upload trained model and relevant files (no checkpoints)
+        if args.log_on_wandb and args.upload_model and _WANDB_AVAILABLE:
+            wandb.save(os.path.join(args.output_dir, "*.*"))
+
         # Load a trained model and vocabulary that you have fine-tuned
         model = AutoModelForSequenceClassification.from_pretrained(args.output_dir)
         tokenizer = AutoTokenizer.from_pretrained(args.output_dir)

--- a/examples/run_glue.py
+++ b/examples/run_glue.py
@@ -522,8 +522,8 @@ def main():
         else:
             wandb.init(config={**vars(args), 'script': os.path.basename(__file__), 'config':config.to_dict(),
                                'tokenizer_config':tokenizer.init_kwargs})
-        # keep track of model topology and gradients
-        wandb.watch(model)
+            # keep track of model topology and gradients
+            wandb.watch(model)
 
     # Training
     if args.do_train:

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -45,6 +45,8 @@ class TrainingArguments:
     warmup_steps: int = field(default=0, metadata={"help": "Linear warmup over warmup_steps."})
 
     logging_steps: int = field(default=500, metadata={"help": "Log every X updates steps."})
+    log_on_wandb: bool = field(default=False, metadata={"help": "Log on Weights & Biases."})
+    upload_model: bool = field(default=False, metadata={"help": "Upload model when log_on_wandb is True."})
     save_steps: int = field(default=500, metadata={"help": "Save checkpoint every X updates steps."})
     save_total_limit: Optional[int] = field(
         default=None,


### PR DESCRIPTION
Hi,

I've been using hugging-face for a while and I've been loving it. I think it could become a central reference for NLP problems. I would like to contribute in solving a few limitations I observed:
* some models don't have clear details on how they have been trained (hyper-parameters) and for which task, making it hard to reproduce their results (and even ensure those results were actually reached) -> ideally we would track & log their training process as well as config parameters used
* some new models keep on being requested/proposed without seeing their actual efficiency -> ideally we would be able to compare them to baselines
* I've seen issues where "better" models are offered to replace previous ones but there is no way to prove they are actually better -> maybe we can add a metrics table (linked to actual runs) to the model card
* it is hard to keep track of models and datasets
* overall I'd like to bring more traceability and transparency between users

This is why I propose to use [Weights & Biases](https://docs.wandb.com/) which is free for open source and will help solve those issues. Also it is already part of Pytorch-Lightning so it will be easy to integrate it with those scripts.

This PR brings :

* arg `--log_on_wandb` will save all config parameters and training/evaluation metrics to W&B
* arg `--upload_model` will upload trained model

See example run on bert-base-cased  -> [W&B run](https://app.wandb.ai/borisd13/transformers-examples/runs/2hkb07jl)

![image](https://user-images.githubusercontent.com/715491/79627095-0fe47b00-80fb-11ea-8428-9fd113f7ed9f.png)

If you navigate around, you will see that config parameters, metrics, gradients, computer resources, trained model, actual code (including git repo & command line used) and stdout have all been uploaded for full traceability and reproducibility.

I can also easily compare bert-base-cased and bert-base-uncased from my [project page](https://app.wandb.ai/borisd13/transformers-examples).

![image](https://user-images.githubusercontent.com/715491/79627629-9438fd00-80ff-11ea-8ef4-727e1f5939c2.png)

This makes it easy to quickly see if a new model is actually interesting.

Finally, this integration let us create [cool reports](https://app.wandb.ai/stacey/keras_finetune/reports/Curriculum-Learning-in-Nature--Vmlldzo1MjcxNw) where graphs directly pool data and are interactive.

If you like it, then I'd love to add other features in later PR's:

* in addition to metrics, track model size & inference speed
* use artifacts (their version control system) to track models & datasets -> central repository that will let us see easily that runs are based on same dataset or same pre-trained model + see all trained tasks associated to one pre-trained model
* log prediction samples (based on the task)
* create a central repo on W&B (entity: hugging-face) to have access to other's people runs
* add the same changes to remaining scripts (should be straight forward as it's just a few lines)
* integrate model card issue template so that we always add a link to a run as well as performance metrics
* add [sweeps](https://docs.wandb.com/sweeps) -> make it easy to optimize hyper-parameters
* we could add a hook to run automatically on all tasks any new model added (and link the run to the model cards)

Please let me know your thoughts and feel free to contact me or Weights & Biases directly to discuss this integration.